### PR TITLE
Seed worker token cache via client

### DIFF
--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,5 +1,21 @@
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type"
+};
+
 export default {
   async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
+    }
+
+    if (request.method === "POST" && url.pathname === "/token") {
+      return handleTokenSeed(request, env, ctx);
+    }
+
     // 1. Get or refresh the access token
     const accessToken = await getAccessToken(env, ctx);
 
@@ -12,12 +28,83 @@ export default {
     return new Response(response.body, {
       status: response.status,
       headers: {
-        "Access-Control-Allow-Origin": "*",
+        ...CORS_HEADERS,
         "Cache-Control": "no-store"
       }
     });
   }
 };
+
+async function handleTokenSeed(request, env, ctx) {
+  let payload;
+
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
+      status: 400,
+      headers: {
+        ...CORS_HEADERS,
+        "Content-Type": "application/json"
+      }
+    });
+  }
+
+  const { refresh_token, access_token, expires_in } = payload ?? {};
+
+  if (typeof refresh_token !== "string" || refresh_token.length === 0) {
+    return new Response(JSON.stringify({ error: "refresh_token is required" }), {
+      status: 400,
+      headers: {
+        ...CORS_HEADERS,
+        "Content-Type": "application/json"
+      }
+    });
+  }
+
+  if (typeof access_token !== "string" || access_token.length === 0) {
+    return new Response(JSON.stringify({ error: "access_token is required" }), {
+      status: 400,
+      headers: {
+        ...CORS_HEADERS,
+        "Content-Type": "application/json"
+      }
+    });
+  }
+
+  const expiresInNumber = Number(expires_in);
+  if (!Number.isFinite(expiresInNumber) || expiresInNumber <= 0) {
+    return new Response(JSON.stringify({ error: "expires_in must be a positive number" }), {
+      status: 400,
+      headers: {
+        ...CORS_HEADERS,
+        "Content-Type": "application/json"
+      }
+    });
+  }
+
+  const expiresBuffer = Math.max(expiresInNumber - 60, 0);
+  const expiresAt = Date.now() + expiresBuffer * 1000;
+
+  ctx.waitUntil(env.TOKEN_CACHE.put("refresh_token", refresh_token));
+  ctx.waitUntil(
+    env.TOKEN_CACHE.put(
+      "token",
+      JSON.stringify({
+        access_token,
+        expires_at: expiresAt
+      }),
+      { expirationTtl: expiresInNumber }
+    )
+  );
+
+  return new Response(JSON.stringify({ status: "ok" }), {
+    headers: {
+      ...CORS_HEADERS,
+      "Content-Type": "application/json"
+    }
+  });
+}
 
 async function getAccessToken(env, ctx) {
   const tokenData = await env.TOKEN_CACHE.get("token", { type: "json" });


### PR DESCRIPTION
## Summary
- add a token seeding endpoint to the Worker so refresh/access tokens can be cached via POST with full CORS support
- have the GitHub Pages client post Spotify token payloads to the Worker and continue using the access token for UI updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb9dd0f2148320ac6c43b78efd02d7